### PR TITLE
新增 翻页操作ACT日志行推送/一键保存空房数据/一键手动上报

### DIFF
--- a/HousingCheck/HousingCheck.csproj
+++ b/HousingCheck/HousingCheck.csproj
@@ -30,6 +30,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <RunPostBuildEvent>Always</RunPostBuildEvent>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Advanced Combat Tracker">
       <HintPath>..\..\HouseCheck\HouseCheck\Advanced Combat Tracker.dll</HintPath>
@@ -78,4 +81,7 @@
     <None Include="Properties\DataSources\PluginControl.datasource" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy C:\Users\Stormkeeper\source\repos\HousingCheck\HousingCheck\bin\Release F:\Test\FFXIV\ACT\Plugins\HousingCheck  /y</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/HousingCheck/HousingItem.cs
+++ b/HousingCheck/HousingItem.cs
@@ -17,6 +17,7 @@ namespace HousingCheck
             Size = _size;
             Price = _price;
             AddTime = DateTime.Now;
+            ExistenceTime = DateTime.Now;
         }
 
 
@@ -30,8 +31,10 @@ namespace HousingCheck
         public string Size { get; set; }
         [DisplayName("价格")]
         public int Price { get; set; }
-        [DisplayName("记录时间")]
+        [DisplayName("首次记录时间")]
         public DateTime AddTime { get; set; }
+        [DisplayName("最后记录时间")]
+        public DateTime ExistenceTime { get; set; }
 
         public bool Equals(HousingItem obj)
         {

--- a/HousingCheck/PluginControl.Designer.cs
+++ b/HousingCheck/PluginControl.Designer.cs
@@ -39,19 +39,24 @@ namespace HousingCheck
             this.checkBoxUpload = new System.Windows.Forms.CheckBox();
             this.groupBoxLog = new System.Windows.Forms.GroupBox();
             this.textBoxLog = new System.Windows.Forms.TextBox();
+            this.groupBoxControl = new System.Windows.Forms.GroupBox();
+            this.buttonCopyToClipboard = new System.Windows.Forms.Button();
+            this.buttonSaveToFile = new System.Windows.Forms.Button();
+            this.buttonUploadOnce = new System.Windows.Forms.Button();
             this.groupBoxTable.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.housingCheckBindingSource)).BeginInit();
             this.groupBoxUpload.SuspendLayout();
             this.groupBoxLog.SuspendLayout();
+            this.groupBoxControl.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBoxTable
             // 
             this.groupBoxTable.Controls.Add(this.dataGridView1);
-            this.groupBoxTable.Location = new System.Drawing.Point(18, 20);
+            this.groupBoxTable.Location = new System.Drawing.Point(18, 18);
             this.groupBoxTable.Name = "groupBoxTable";
-            this.groupBoxTable.Size = new System.Drawing.Size(661, 600);
+            this.groupBoxTable.Size = new System.Drawing.Size(538, 602);
             this.groupBoxTable.TabIndex = 0;
             this.groupBoxTable.TabStop = false;
             this.groupBoxTable.Text = "在售列表";
@@ -59,12 +64,15 @@ namespace HousingCheck
             // dataGridView1
             // 
             this.dataGridView1.AllowUserToOrderColumns = true;
-            this.dataGridView1.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.dataGridView1.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.DisplayedCells;
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView1.Location = new System.Drawing.Point(7, 20);
+            this.dataGridView1.Location = new System.Drawing.Point(7, 18);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.ReadOnly = true;
-            this.dataGridView1.Size = new System.Drawing.Size(648, 574);
+            this.dataGridView1.Size = new System.Drawing.Size(525, 578);
             this.dataGridView1.TabIndex = 0;
             // 
             // groupBoxUpload
@@ -72,9 +80,9 @@ namespace HousingCheck
             this.groupBoxUpload.Controls.Add(this.checkBoxML);
             this.groupBoxUpload.Controls.Add(this.textBoxUpload);
             this.groupBoxUpload.Controls.Add(this.checkBoxUpload);
-            this.groupBoxUpload.Location = new System.Drawing.Point(685, 20);
+            this.groupBoxUpload.Location = new System.Drawing.Point(562, 18);
             this.groupBoxUpload.Name = "groupBoxUpload";
-            this.groupBoxUpload.Size = new System.Drawing.Size(321, 164);
+            this.groupBoxUpload.Size = new System.Drawing.Size(321, 138);
             this.groupBoxUpload.TabIndex = 1;
             this.groupBoxUpload.TabStop = false;
             this.groupBoxUpload.Text = "上报设置";
@@ -84,9 +92,9 @@ namespace HousingCheck
             this.checkBoxML.AutoSize = true;
             this.checkBoxML.Checked = true;
             this.checkBoxML.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxML.Location = new System.Drawing.Point(104, 20);
+            this.checkBoxML.Location = new System.Drawing.Point(114, 18);
             this.checkBoxML.Name = "checkBoxML";
-            this.checkBoxML.Size = new System.Drawing.Size(82, 17);
+            this.checkBoxML.Size = new System.Drawing.Size(78, 16);
             this.checkBoxML.TabIndex = 2;
             this.checkBoxML.Text = "只上报M/L";
             this.checkBoxML.UseVisualStyleBackColor = true;
@@ -94,53 +102,93 @@ namespace HousingCheck
             // textBoxUpload
             // 
             this.textBoxUpload.Enabled = false;
-            this.textBoxUpload.Location = new System.Drawing.Point(7, 44);
+            this.textBoxUpload.Location = new System.Drawing.Point(7, 41);
             this.textBoxUpload.Multiline = true;
             this.textBoxUpload.Name = "textBoxUpload";
             this.textBoxUpload.ReadOnly = true;
-            this.textBoxUpload.Size = new System.Drawing.Size(308, 114);
+            this.textBoxUpload.Size = new System.Drawing.Size(308, 91);
             this.textBoxUpload.TabIndex = 1;
             // 
             // checkBoxUpload
             // 
             this.checkBoxUpload.AutoSize = true;
-            this.checkBoxUpload.Location = new System.Drawing.Point(7, 20);
+            this.checkBoxUpload.Location = new System.Drawing.Point(7, 18);
             this.checkBoxUpload.Name = "checkBoxUpload";
-            this.checkBoxUpload.Size = new System.Drawing.Size(74, 17);
+            this.checkBoxUpload.Size = new System.Drawing.Size(96, 16);
             this.checkBoxUpload.TabIndex = 0;
-            this.checkBoxUpload.Text = "开启上报";
+            this.checkBoxUpload.Text = "开启自动上报";
             this.checkBoxUpload.UseVisualStyleBackColor = true;
             this.checkBoxUpload.CheckedChanged += new System.EventHandler(this.checkBoxUpload_CheckedChanged);
             // 
             // groupBoxLog
             // 
             this.groupBoxLog.Controls.Add(this.textBoxLog);
-            this.groupBoxLog.Location = new System.Drawing.Point(686, 191);
+            this.groupBoxLog.Location = new System.Drawing.Point(563, 223);
             this.groupBoxLog.Name = "groupBoxLog";
-            this.groupBoxLog.Size = new System.Drawing.Size(320, 429);
+            this.groupBoxLog.Size = new System.Drawing.Size(320, 397);
             this.groupBoxLog.TabIndex = 2;
             this.groupBoxLog.TabStop = false;
             this.groupBoxLog.Text = "日志";
             // 
             // textBoxLog
             // 
-            this.textBoxLog.Location = new System.Drawing.Point(7, 20);
+            this.textBoxLog.Location = new System.Drawing.Point(7, 18);
             this.textBoxLog.Multiline = true;
             this.textBoxLog.Name = "textBoxLog";
             this.textBoxLog.ReadOnly = true;
             this.textBoxLog.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.textBoxLog.Size = new System.Drawing.Size(307, 403);
+            this.textBoxLog.Size = new System.Drawing.Size(307, 373);
             this.textBoxLog.TabIndex = 0;
+            // 
+            // groupBoxControl
+            // 
+            this.groupBoxControl.Controls.Add(this.buttonCopyToClipboard);
+            this.groupBoxControl.Controls.Add(this.buttonSaveToFile);
+            this.groupBoxControl.Controls.Add(this.buttonUploadOnce);
+            this.groupBoxControl.Location = new System.Drawing.Point(563, 162);
+            this.groupBoxControl.Name = "groupBoxControl";
+            this.groupBoxControl.Size = new System.Drawing.Size(320, 55);
+            this.groupBoxControl.TabIndex = 3;
+            this.groupBoxControl.TabStop = false;
+            this.groupBoxControl.Text = "操作";
+            // 
+            // buttonCopyToClipboard
+            // 
+            this.buttonCopyToClipboard.Location = new System.Drawing.Point(216, 20);
+            this.buttonCopyToClipboard.Name = "buttonCopyToClipboard";
+            this.buttonCopyToClipboard.Size = new System.Drawing.Size(98, 23);
+            this.buttonCopyToClipboard.TabIndex = 0;
+            this.buttonCopyToClipboard.Text = "复制到剪贴板";
+            this.buttonCopyToClipboard.UseVisualStyleBackColor = true;
+            // 
+            // buttonSaveToFile
+            // 
+            this.buttonSaveToFile.Location = new System.Drawing.Point(111, 20);
+            this.buttonSaveToFile.Name = "buttonSaveToFile";
+            this.buttonSaveToFile.Size = new System.Drawing.Size(98, 23);
+            this.buttonSaveToFile.TabIndex = 0;
+            this.buttonSaveToFile.Text = "保存到文件";
+            this.buttonSaveToFile.UseVisualStyleBackColor = true;
+            // 
+            // buttonUploadOnce
+            // 
+            this.buttonUploadOnce.Location = new System.Drawing.Point(6, 20);
+            this.buttonUploadOnce.Name = "buttonUploadOnce";
+            this.buttonUploadOnce.Size = new System.Drawing.Size(98, 23);
+            this.buttonUploadOnce.TabIndex = 0;
+            this.buttonUploadOnce.Text = "手动上报一次";
+            this.buttonUploadOnce.UseVisualStyleBackColor = true;
             // 
             // PluginControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.groupBoxControl);
             this.Controls.Add(this.groupBoxLog);
             this.Controls.Add(this.groupBoxUpload);
             this.Controls.Add(this.groupBoxTable);
             this.Name = "PluginControl";
-            this.Size = new System.Drawing.Size(1075, 651);
+            this.Size = new System.Drawing.Size(940, 655);
             this.groupBoxTable.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.housingCheckBindingSource)).EndInit();
@@ -148,6 +196,7 @@ namespace HousingCheck
             this.groupBoxUpload.PerformLayout();
             this.groupBoxLog.ResumeLayout(false);
             this.groupBoxLog.PerformLayout();
+            this.groupBoxControl.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -163,5 +212,9 @@ namespace HousingCheck
         public System.Windows.Forms.TextBox textBoxLog;
         public System.Windows.Forms.TextBox textBoxUpload;
         public System.Windows.Forms.CheckBox checkBoxML;
+        private System.Windows.Forms.GroupBox groupBoxControl;
+        public System.Windows.Forms.Button buttonCopyToClipboard;
+        public System.Windows.Forms.Button buttonSaveToFile;
+        public System.Windows.Forms.Button buttonUploadOnce;
     }
 }

--- a/HousingCheck/PluginControl.cs
+++ b/HousingCheck/PluginControl.cs
@@ -39,7 +39,8 @@ namespace HousingCheck
                 xdo.Load(SettingsFile);
                 XmlNode head = xdo.SelectSingleNode("Config");
                 textBoxUpload.Text = head?.SelectSingleNode("OtterURL")?.InnerText;
-                checkBoxUpload.Checked = bool.Parse(head?.SelectSingleNode("AutoStart")?.InnerText ?? "false");
+                checkBoxUpload.Checked = bool.Parse(head?.SelectSingleNode("AutoUpload")?.InnerText ?? "false");
+                checkBoxML.Checked = bool.Parse(head?.SelectSingleNode("ML")?.InnerText ?? "true");
             }
 
         }
@@ -50,7 +51,8 @@ namespace HousingCheck
             xWriter.WriteStartDocument(true);
             xWriter.WriteStartElement("Config");    // <Config>
             xWriter.WriteElementString("OtterURL", textBoxUpload.Text);
-            xWriter.WriteElementString("AutoStart", checkBoxUpload.Checked.ToString());
+            xWriter.WriteElementString("AutoUpload", checkBoxUpload.Checked.ToString());
+            xWriter.WriteElementString("ML", checkBoxML.Checked.ToString());
             xWriter.WriteEndElement();              // </Config>
             xWriter.WriteEndDocument();             // Tie up loose ends (shouldn't be any)
             xWriter.Flush();                        // Flush the file buffer to disk


### PR DESCRIPTION
包括小区翻页操作在内的log信息推送到ACT日志行
UI增加“手动上报” “保存文件” “复制到剪贴板”三个按钮导出list内空房数据
HousingItem增加最后一次查到特定空房的时间，查到重复房更新该时间和价格

已知问题：小区翻页速度过快会丢失一些UI上显示的日志数据，但目前看来不影响list数据记录和ACT日志输出